### PR TITLE
Add type check in CI, ignoring the result

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,5 +20,7 @@ jobs:
     - name: Lint with Rubocop
       run: bundle exec rake rubocop
     - name: Check types
-      # TODO: swallowing result until types pass
-      run: bundle exec rake steep:check || true
+      run: |
+        bundle exec rbs collection install
+        # TODO: swallowing result until types pass
+        bundle exec rake steep:check || true


### PR DESCRIPTION
Ignoring results because typing is not yet complete: this is to set up the struts of type checking execution in CI.